### PR TITLE
Bug in generated code

### DIFF
--- a/app/templates/api_version_3_0/src/twigextensions/_TwigExtension.php
+++ b/app/templates/api_version_3_0/src/twigextensions/_TwigExtension.php
@@ -90,7 +90,7 @@ class <%= pluginHandle %>TwigExtension extends \Twig_Extension
     public function getFunctions()
     {
         return [
-            new \Twig_SimpleFunction('someFilter', [$this, 'someInternalFunction']),
+            new \Twig_SimpleFunction('someFunction', [$this, 'someInternalFunction']),
         ];
     }
 


### PR DESCRIPTION
The documented example said the example function was called `someFunction` but it was called `someFilter`, probably as result of a copy/paste. This should fix that.