### PR TITLE
"Callback must be a function" error on Node.js v10.0.0

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -291,8 +291,16 @@ module.exports = yo.generators.Base.extend({
 
 /* -- Write the answers out to a JSON file */
 
-        fs.writeFile(this.destDir + PLUGIN_CONF_FILE_NAME, this.rawAnswers, "utf8");
-        },
+        fs.writeFile(
+            this.destDir + PLUGIN_CONF_FILE_NAME,
+            this.rawAnswers,
+            "utf8",
+            (err) => {
+                if (err) throw err;
+                this.log(chalk.green('> Configuration synced to filesystem.'));
+            }
+        );
+    },
 
 /* -- writing -- Where you write the generator specific files (routes, controllers, etc) */
 


### PR DESCRIPTION
Running the generator resulted in the following error with Node.js v10.0.0: 

```
[ Configuring ]
+ Creating Craft plugin folder billingoforcraftcommerce
events.js:167
      throw er; // Unhandled 'error' event
      ^

TypeError [ERR_INVALID_CALLBACK]: Callback must be a function
    at maybeCallback (fs.js:124:9)
    at Object.fs.writeFile (fs.js:1244:14)
    at child.configuring (/usr/lib/node_modules/generator-craftplugin/app/index.js:294:12)
    at /usr/lib/node_modules/generator-craftplugin/node_modules/yeoman-generator/lib/base.js:429:16
    at runCallback (timers.js:696:18)
    at tryOnImmediate (timers.js:667:5)
    at processImmediate (timers.js:649:5)
Emitted 'error' event at:
    at /usr/lib/node_modules/generator-craftplugin/node_modules/yeoman-generator/lib/base.js:437:14
    at runCallback (timers.js:696:18)
    at tryOnImmediate (timers.js:667:5)
    at processImmediate (timers.js:649:5)
```

According to the [documentation](https://nodejs.org/api/fs.html#fs_fs_writefile_file_data_options_callback) a 4th argument is needed on fs.writeFile (a callback). It was missing until now. After this PR everything seems normal with Node.js v10.0.0, too.