### PR TITLE
Update _cpsection.twig

### DIFF
--- a/app/templates/api_version_3_0/src/templates/_cpsection.twig
+++ b/app/templates/api_version_3_0/src/templates/_cpsection.twig
@@ -122,11 +122,9 @@
 <% if ((typeof codeComments !== 'undefined') && (codeComments)) { -%>
 {# Content that should appear in the page header#}
 <% } -%>
-{% set extraPageHeaderHtml %}
-    <div class="buttons">
-        <a href="{{ pluginCpUrl }}" class="btn submit add icon">{{ "Click Me!"|t('<%= pluginKebabHandle %>') }}</a>
-    </div>
-{% endset %}
+{% block actionButton %}
+    <a href="{{ pluginCpUrl }}" class="btn submit add icon">{{ "Click Me!"|t('<%= pluginKebabHandle %>') }}</a>
+{% endblock %}
 
 <% if ((typeof codeComments !== 'undefined') && (codeComments)) { -%>
 {# The content of the CP Section#}


### PR DESCRIPTION
Support for the extraPageHeaderHtml variable has been removed. To create a primary action button in the page header, use the new actionButton block.

[https://docs.craftcms.com/v3/updating-plugins.html#extrapageheaderhtml](url)