### PR TITLE
Skippable files - prevent certain deleted files from being recreated

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -331,23 +331,7 @@ module.exports = yo.generators.Base.extend({
                                 dirPrefix = thisPrefix.directorize() + file.dirSubPrefix;
                             }
                             destFile = _this.destDir + file.destDir + dirPrefix + _this.answers.pluginHandle + thisPrefix + file.dest;
-                            // Only write it if the file doesn't exist already
-                            if (!fs.existsSync(destFile)) {
-                                _this.log('+ ' + _this.answers.templatesDir + "/" + file.src + ' wrote to ' + chalk.green(destFile));
-                                _this.answers['index'] = index;
-                                if (file.justCopy) {
-                                    _this.fs.copy(
-                                        _this.templatePath(file.src),
-                                        _this.destinationPath(destFile)
-                                        );
-                                } else {
-                                    _this.fs.copyTpl(
-                                        _this.templatePath(file.src),
-                                        _this.destinationPath(destFile),
-                                        _this.answers
-                                        );
-                                    }
-                                }
+                            _this._writeFile(file, destFile, index);
                             });
                         } else {
 /* -- Handle templates that only have a prefix */
@@ -359,23 +343,7 @@ module.exports = yo.generators.Base.extend({
                             destFile = this.destDir + file.destDir + dirPrefix + this.answers.pluginKebabHandle + file.dest;
                         else
                             destFile = this.destDir + file.destDir + dirPrefix + this.answers.pluginHandle  + file.dest;
-                        // Only write it if the file doesn't exist already
-                        if (!fs.existsSync(destFile)) {
-                            this.log('+ ' + this.answers.templatesDir + "/" + file.src + ' wrote to ' + chalk.green(destFile));
-                            this.answers['index'] = 0;
-                            if (file.justCopy) {
-                                _this.fs.copy(
-                                    _this.templatePath(file.src),
-                                    _this.destinationPath(destFile)
-                                    );
-                            } else {
-                                this.fs.copyTpl(
-                                    this.templatePath(file.src),
-                                    this.destinationPath(destFile),
-                                    this.answers
-                                    );
-                                }
-                            }
+                        this._writeFile(file, destFile, 0);
                         }
                     } else {
                     if (file.subPrefix) {
@@ -391,23 +359,7 @@ module.exports = yo.generators.Base.extend({
                                 thisPrefix = thisPrefix.kebabize();
                                 }
                             destFile = _this.destDir + file.destDir + dirPrefix + thisPrefix + file.dest;
-                            // Only write it if the file doesn't exist already
-                            if (!fs.existsSync(destFile)) {
-                                _this.log('+ ' + _this.answers.templatesDir + "/" + file.src + ' wrote to ' + chalk.green(destFile));
-                                _this.answers['index'] = index;
-                                if (file.justCopy) {
-                                    _this.fs.copy(
-                                        _this.templatePath(file.src),
-                                        _this.destinationPath(destFile)
-                                        );
-                                } else {
-                                    _this.fs.copyTpl(
-                                        _this.templatePath(file.src),
-                                        _this.destinationPath(destFile),
-                                        _this.answers
-                                        );
-                                    }
-                                }
+                            _this._writeFile(file, destFile, index);
                             });
                         } else {
 /* -- Handle templates that are not prefixed */
@@ -416,23 +368,7 @@ module.exports = yo.generators.Base.extend({
                             dirPrefix = file.dirSubPrefix;
                         }
                         destFile = this.destDir + file.destDir + dirPrefix + file.dest;
-                        // Only write it if the file doesn't exist already
-                        if (!fs.existsSync(destFile)) {
-                            this.log('+ ' + this.answers.templatesDir + "/" + file.src + ' wrote to ' + chalk.green(destFile));
-                            this.answers['index'] = 0;
-                            if (file.justCopy) {
-                                _this.fs.copy(
-                                    _this.templatePath(file.src),
-                                    _this.destinationPath(destFile)
-                                    );
-                            } else {
-                                this.fs.copyTpl(
-                                    this.templatePath(file.src),
-                                    this.destinationPath(destFile),
-                                    this.answers
-                                    );
-                                }
-                            }
+                        this._writeFile(file, destFile, 0);
                         }
                     }
                 }
@@ -454,8 +390,8 @@ module.exports = yo.generators.Base.extend({
                     });
                 }
                 if (!skip) {
-                    // Only write it if the file doesn't exist already
-                    if (!fs.existsSync(destFile)) {
+                    // Only write it if the file doesn't exist already and we're generating the full plugin or it is not skippable
+                    if (!fs.existsSync(destFile) && (this.generateFullPlugin || !file.skippable)) {
                     this.log('+ ' + this.answers.templatesDir + "/" + file.src + ' copied to ' + chalk.green(destFile));
                     this.fs.copy(
                         this.templatePath(file.src),
@@ -494,6 +430,33 @@ module.exports = yo.generators.Base.extend({
         this.log('The default LICENSE.txt is the ' + chalk.green('MIT license') +  '; feel free to change it as you see fit.');
         this.log(chalk.green('> All set.  Have a nice day.'));
         },
+
+    _writeFile: function(file, destFile, index) {
+        // Only write it if the file doesn't exist already
+        if (!fs.existsSync(destFile)) {
+            this.answers['index'] = index;
+
+            // Don't recreate skippable files
+            if (!this.generateFullPlugin && file.skippable) {
+              return;
+            }
+
+            if (file.justCopy) {
+                this.fs.copy(
+                    this.templatePath(file.src),
+                    this.destinationPath(destFile)
+                    );
+            } else {
+                this.fs.copyTpl(
+                    this.templatePath(file.src),
+                    this.destinationPath(destFile),
+                    this.answers
+                    );
+                }
+
+            this.log('+ ' + this.answers.templatesDir + "/" + file.src + ' wrote to ' + chalk.green(destFile));
+        }
+    },
 
 });
 

--- a/app/templates/target_apis/api_version_2_5.json
+++ b/app/templates/target_apis/api_version_2_5.json
@@ -233,25 +233,29 @@
             "src": "_README.md",
             "destDir": "",
             "dest": "README.md",
-            "prefix": false
+            "prefix": false,
+            "skippable": true
         },
         {
             "src": "_CHANGELOG.md",
             "destDir": "",
             "dest": "CHANGELOG.md",
-            "prefix": false
+            "prefix": false,
+            "skippable": true
         },
         {
             "src": "_LICENSE.txt",
             "destDir": "",
             "dest": "LICENSE.txt",
-            "prefix": false
+            "prefix": false,
+            "skippable": true
         },
         {
             "src": "_releases.json",
             "destDir": "",
             "dest": "releases.json",
-            "prefix": false
+            "prefix": false,
+            "skippable": true
         },
         {
             "src": "_composer.json",
@@ -445,7 +449,8 @@
             "src": "translations/_en.php",
             "destDir": "translations/",
             "dest": "en.php",
-            "prefix": false
+            "prefix": false,
+            "skippable": true
         },
         {
             "src": "twigextensions/_TwigExtension.php",
@@ -478,17 +483,21 @@
     ],
     "BOILERPLATE_FILES": [
         {
-            "src": "resources/icon-mask.svg"
+            "src": "resources/icon-mask.svg",
+            "skippable": true
         },
         {
-            "src": "resources/icon.svg"
+            "src": "resources/icon.svg",
+            "skippable": true
         },
         {
             "src": "resources/images/plugin.png",
-            "requires": ["settings"]
+            "requires": ["settings"],
+            "skippable": true
         },
         {
-            "src": "resources/screenshots/plugin_logo.png"
+            "src": "resources/screenshots/plugin_logo.png",
+            "skippable": true
         }
     ],
     "END_INSTALL_COMMANDS": [

--- a/app/templates/target_apis/api_version_3_0.json
+++ b/app/templates/target_apis/api_version_3_0.json
@@ -260,19 +260,22 @@
             "src": "_README.md",
             "destDir": "",
             "dest": "README.md",
-            "prefix": false
+            "prefix": false,
+            "skippable": true
         },
         {
             "src": "_CHANGELOG.md",
             "destDir": "",
             "dest": "CHANGELOG.md",
-            "prefix": false
+            "prefix": false,
+            "skippable": true
         },
         {
             "src": "_LICENSE.md",
             "destDir": "",
             "dest": "LICENSE.md",
-            "prefix": false
+            "prefix": false,
+            "skippable": true
         },
         {
             "src": "_composer.json",
@@ -284,7 +287,8 @@
             "src": "_gitignore",
             "destDir": "",
             "dest": ".gitignore",
-            "prefix": false
+            "prefix": false,
+            "skippable": true
         },
         {
             "src": "src/_config.php",
@@ -595,7 +599,8 @@
             "destDir": "src/translations/en/",
             "dest": ".php",
             "kebabcasePrefix": true,
-            "prefix": true
+            "prefix": true,
+            "skippable": true
         },
         {
             "src": "src/twigextensions/_TwigExtension.php",
@@ -626,7 +631,8 @@
             "requires": ["settings"],
             "dirSubPrefix": "/dist/img/",
             "justCopy": true,
-            "prefix": true
+            "prefix": true,
+            "skippable": true
         },
         {
             "src": "src/assetbundles/pluginresources/dist/css/_style.css",
@@ -647,13 +653,16 @@
     ],
     "BOILERPLATE_FILES": [
         {
-            "src": "src/icon-mask.svg"
+            "src": "src/icon-mask.svg",
+            "skippable": true
         },
         {
-            "src": "src/icon.svg"
+            "src": "src/icon.svg",
+            "skippable": true
         },
         {
-            "src": "resources/img/plugin-logo.png"
+            "src": "resources/img/plugin-logo.png",
+            "skippable": true
         }
     ],
     "END_INSTALL_COMMANDS": [

--- a/app/templates/target_apis/module_api_version_3_0.json
+++ b/app/templates/target_apis/module_api_version_3_0.json
@@ -236,25 +236,29 @@
             "src": "_README.md",
             "destDir": "",
             "dest": "README.md",
-            "prefix": false
+            "prefix": false,
+            "skippable": true
         },
         {
             "src": "_CHANGELOG.md",
             "destDir": "",
             "dest": "CHANGELOG.md",
-            "prefix": false
+            "prefix": false,
+            "skippable": true
         },
         {
             "src": "_LICENSE.md",
             "destDir": "",
             "dest": "LICENSE.md",
-            "prefix": false
+            "prefix": false,
+            "skippable": true
         },
         {
             "src": "_gitignore",
             "destDir": "",
             "dest": ".gitignore",
-            "prefix": false
+            "prefix": false,
+            "skippable": true
         },
         {
             "src": "src/console/controllers/_Command.php",
@@ -506,7 +510,8 @@
             "destDir": "src/translations/en/",
             "dest": ".php",
             "kebabcasePrefix": true,
-            "prefix": true
+            "prefix": true,
+            "skippable": true
         },
         {
             "src": "src/twigextensions/_TwigExtension.php",
@@ -535,7 +540,8 @@
             "dest": "-icon.svg",
             "dirSubPrefix": "/dist/img/",
             "justCopy": true,
-            "prefix": true
+            "prefix": true,
+            "skippable": true
         },
         {
             "src": "src/assetbundles/moduleresources/dist/css/_style.css",


### PR DESCRIPTION
Related to #55

Adds support for a `skippable` property for `TEMPLATE_FILES` and `BOILERPLATE_FILES` items.

When running the generator for a previously generated plugin, files marked as skippable will not be recreated if they no longer exist.

At this stage I've marked the following files as skippable:
-  Markdown/text files
- .gitignore
- releases.json
- Translations
- Icons

It might be worth considering whether to make twig, css and js files skippable as well (in case they were renamed or not required).

Currently there's no opt-in or out for this. I could add an option to ask the user whether they want to recreate skippable files or not.

I also haven't adjusted the output - we could report the skipped files to the user.