### PR TITLE
Adjust the composer.json template

### DIFF
--- a/app/templates/api_version_3_0/_composer.json
+++ b/app/templates/api_version_3_0/_composer.json
@@ -42,6 +42,9 @@
 <% } else { -%>
         "hasCpSection": false,
 <% } -%>
+        "developer": "<%= pluginAuthorName %>",
+        "developerUrl": "<%= pluginAuthorUrl %>",
+        "documentationUrl": "<%= pluginDocsUrl %>",
         "changelogUrl": "<%= pluginChangelogUrl %>",
 <% if (pluginComponents.indexOf('services') >= 0){ -%>
 <% var components = serviceName -%>


### PR DESCRIPTION
It appears that in some instances during composer install/update process the **support** section is removed from the `composer.lock` file and that causes the _documentation_ link to not appear on the Control Panel > Settings > Plugins page.

After some digging and testing, including the `documentationUrl` item in the **extra** section should help the situation.

Also, while reviewing some other popular Craft plugins, I noticed that the following items were also present in the **extra** section so I included those as well:

- developer
- developerUrl