### PR TITLE
removing composer/instalers

### DIFF
--- a/app/templates/api_version_2_5/_composer.json
+++ b/app/templates/api_version_2_5/_composer.json
@@ -9,6 +9,6 @@
 		}
 	],
 	"require": {
-		"composer/installers": "~1.0"
+		"craftcms/cms": "^3.0"
 	}
 }


### PR DESCRIPTION
The composer/installers package will look for a `craft/plugins/{$name}` directory and this is a Craft 2 construct. So removing this so nobody else will have this issue. Took a week to debug this guy! 