### PR TITLE
Since node 10, it is mandatory to pass a callback on fs.writefile()

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -291,7 +291,7 @@ module.exports = yo.generators.Base.extend({
 
 /* -- Write the answers out to a JSON file */
 
-        fs.writeFile(this.destDir + PLUGIN_CONF_FILE_NAME, this.rawAnswers, "utf8");
+        fs.writeFile(this.destDir + PLUGIN_CONF_FILE_NAME, this.rawAnswers, "utf8", () => {});
         },
 
 /* -- writing -- Where you write the generator specific files (routes, controllers, etc) */


### PR DESCRIPTION
Since node 10, [it is mandatory to pass a callback on fs.writefile()](https://nodejs.org/api/fs.html#fs_fs_writefile_file_data_options_callback
)
This was not the case on line 294 of the index.js file, so it was throwing the following error :
`Callback must be a function. Received 'utf8'`
I added an empty callback function to correct the problem. It works now. 
Feel free to let me know if I made any mystake. Thank you for ,your work, and have a nice day.