### PR TITLE
Move `hasCpSettings` and `hasCpSection` to plugin class

### DIFF
--- a/app/templates/api_version_3_0/_composer.json
+++ b/app/templates/api_version_3_0/_composer.json
@@ -32,16 +32,6 @@
     "extra": {
         "name": "<%- pluginName %>",
         "handle": "<%= pluginKebabHandle %>",
-<% if (pluginComponents.indexOf('settings') >= 0){ -%>
-        "hasCpSettings": true,
-<% } else { -%>
-        "hasCpSettings": false,
-<% } -%>
-<% if (pluginComponents.indexOf('cpsection') >= 0){ -%>
-        "hasCpSection": true,
-<% } else { -%>
-        "hasCpSection": false,
-<% } -%>
         "changelogUrl": "<%= pluginChangelogUrl %>",
 <% if (pluginComponents.indexOf('services') >= 0){ -%>
 <% var components = serviceName -%>

--- a/app/templates/api_version_3_0/src/_Plugin.php
+++ b/app/templates/api_version_3_0/src/_Plugin.php
@@ -182,6 +182,40 @@ class <%= pluginHandle %> extends Plugin
 <% } -%>
     public $schemaVersion = '<%= pluginVersion %>';
 
+<% if ((typeof codeComments !== 'undefined') && (codeComments)) { -%>
+    /**
+     * Set to `true` if the plugin should have a settings view in the control panel.
+     *
+     * @var bool
+     */
+<% } else { -%>
+    /**
+     * @var bool
+     */
+<% } -%>
+<% if (pluginComponents.indexOf('settings') >= 0){ -%>
+    public $hasCpSettings = true;
+<% } else { -%>
+    public $hasCpSettings = false;
+<% } -%>
+
+<% if ((typeof codeComments !== 'undefined') && (codeComments)) { -%>
+    /**
+     * Set to `true` if the plugin should have its own section (main nav item) in the control panel.
+     *
+     * @var bool
+     */
+<% } else { -%>
+    /**
+     * @var bool
+     */
+<% } -%>
+<% if (pluginComponents.indexOf('cpsection') >= 0){ -%>
+    public $hasCpSection = true;
+<% } else { -%>
+    public $hasCpSection = false;
+<% } -%>
+
     // Public Methods
     // =========================================================================
 


### PR DESCRIPTION
Removes these settings from `composer.json` and instead defines them with public properties on the Plugin class. The Composer route has caused some confusion and using class properties is a bit more straightforward.