### PR TITLE
Update `fs` functions for node 12.11.1

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -57,7 +57,7 @@ module.exports = yo.generators.Base.extend({
         this.generateFullPlugin = true;
         if (fs.existsSync(PLUGIN_CONF_FILE_NAME)) {
             this.generateFullPlugin = false;
-            var data = fs.readFileSync(PLUGIN_CONF_FILE_NAME);
+            var data = fs.readFileSync(PLUGIN_CONF_FILE_NAME, 'utf8');
             var obj = JSON.parse(data);
             for (var property in obj) {
                 if (obj.hasOwnProperty(property)) {
@@ -75,12 +75,12 @@ module.exports = yo.generators.Base.extend({
 /* -- Load in our API JSON configs */
 
         path = this.sourceRoot() + TARGET_APIS_DIR;
-        fs.readdirSync(path).forEach(function(file, index) {
+        fs.readdirSync(path, 'utf8').forEach(function(file, index) {
             var curPath = path + "/" + file;
             if (!fs.statSync(curPath).isDirectory()) {
                 var ext = file.substr(file.lastIndexOf('.') + 1);
                 if (ext == 'json') {
-                    var data = fs.readFileSync(curPath);
+                    var data = fs.readFileSync(curPath, 'utf8');
                     var obj = JSON.parse(data);
 /* -- Fill in the API_QUESTIONS with the found target APIs */
                     apis[obj.API_KEY] = obj;
@@ -291,7 +291,7 @@ module.exports = yo.generators.Base.extend({
 
 /* -- Write the answers out to a JSON file */
 
-        fs.writeFile(this.destDir + PLUGIN_CONF_FILE_NAME, this.rawAnswers, "utf8");
+        fs.writeFile(this.destDir + PLUGIN_CONF_FILE_NAME, this.rawAnswers, function() {});
         },
 
 /* -- writing -- Where you write the generator specific files (routes, controllers, etc) */


### PR DESCRIPTION
Testing https://github.com/nystudio107/generator-craftplugin/pull/94 locally was tricky. Stepping node back to 6.17.1 led to a bunch of breakages, and `yo craftplugin` nearly worked until `fs` interactions, which would throw errors to the tune of

```bash
+ Creating Craft plugin folder generic
events.js:187
      throw er; // Unhandled 'error' event
      ^

TypeError [ERR_INVALID_CALLBACK]: Callback must be a function. Received undefined
    at maybeCallback (fs.js:146:9)
    at Object.writeFile (fs.js:1245:14)
    at child.configuring (/path/to/generator-craftplugin/app/index.js:294:12)
    at /path/to/generator-craftplugin/node_modules/yeoman-generator/lib/base.js:429:16
    at processImmediate (internal/timers.js:439:21)
    at process.topLevelDomainCallback (domain.js:131:23)
Emitted 'error' event on child instance at:
    at /path/to/generator-craftplugin/node_modules/yeoman-generator/lib/base.js:437:14
    at processImmediate (internal/timers.js:439:21)
    at process.topLevelDomainCallback (domain.js:131:23)
``` 

Apparently `fs` methods differ slightly in node 12, so the changes in this PR allow `yo craftplugin` to work fully—and generate a plugin as expected—running node 12.11.1. (I alternatively tried updating the npm dependencies, but Yeoman 1.0 introduced breaking changes I wasn’t immediately sure how to resolve.)

Submitting as a PR since I’m not sure what kind of terrors this could introduce for pluginfactory.io.